### PR TITLE
Fix: Remove unused imports

### DIFF
--- a/src/app/prompt-to-prototype/page.tsx
+++ b/src/app/prompt-to-prototype/page.tsx
@@ -906,9 +906,3 @@ export default function PromptToPrototypePage() {
     </div>
   );
 }
-
-    
-
-    
-
-    

--- a/src/app/script-analyzer/page.tsx
+++ b/src/app/script-analyzer/page.tsx
@@ -253,7 +253,7 @@ export default function ScriptAnalyzerPage() {
             </Card>
           )}
            <p className="mt-8 text-xs text-muted-foreground text-center">
-              AI Output Transparency: Analysis and suggestions are AI-generated. The &quot;section&quot; for suggestions must be an exact verbatim quote from your script for &quot;Apply Suggestion&quot; to work correctly. Review and refine all changes.
+              AI Output Transparency: Analysis and suggestions are AI-generated. The &#34;section&#34; for suggestions must be an exact verbatim quote from your script for &#34;Apply Suggestion&#34; to work correctly. Review and refine all changes.
  </p>
         </div>
       )}

--- a/src/app/storyboard-studio/page.tsx
+++ b/src/app/storyboard-studio/page.tsx
@@ -145,7 +145,7 @@ export default function StoryboardStudioPage() {
     try {
       await navigator.clipboard.writeText(textToCopy);
       toast({ title: `${itemName} Copied!`, description: `${itemName} has been copied.`, action: <CheckCircle className="text-green-500" /> });
-    } catch (err) {
+    } catch {
       toast({ title: "Copy Failed", description: `Could not copy ${itemName}. Please try again.`, variant: "destructive" });
     }
   };

--- a/src/components/layout/header.tsx
+++ b/src/components/layout/header.tsx
@@ -5,7 +5,6 @@ import { SidebarTrigger } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
 import { Sheet, SheetContent, SheetTrigger } from "@/components/ui/sheet"
 import { Menu } from 'lucide-react';
-import Link from 'next/link';
 import { AppSidebar } from './sidebar'; // Import AppSidebar for mobile view
 
 export function AppHeader() {

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -14,7 +14,7 @@ import {
 } from '@/components/ui/sidebar';
 import { Button } from '@/components/ui/button';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
-import { LayoutDashboard, Sparkles, ScanText, Kanban, Users, Film, Drama, Settings, LogOut, LayoutGrid, Edit2 } from 'lucide-react'; // Added LayoutGrid
+import { LayoutDashboard, Sparkles, ScanText, Kanban, Users, Film, Drama, Settings, LogOut, LayoutGrid } from 'lucide-react'; // Added LayoutGrid
 import { cn } from '@/lib/utils'; // Added LayoutGrid
 import { Skeleton } from '../ui/skeleton';
 import { useEffect, useState } from 'react';


### PR DESCRIPTION
Removed unused `Link` import from `src/components/layout/header.tsx`. Removed unused `Edit2` import from `src/components/layout/sidebar.tsx`.

I attempted to fix other lint errors but the linter did not recognize the changes. These may require your manual intervention.