### PR TITLE
Fix: Correct parsing error by declaring moodBoardPositionalLabels

### DIFF
--- a/src/app/prompt-to-prototype/page.tsx
+++ b/src/app/prompt-to-prototype/page.tsx
@@ -45,11 +45,11 @@ interface ResultCardProps {
 
 const PLACEHOLDER_IMAGE_URL_TEXT = "Image+Gen+Failed";
 
+const moodBoardPositionalLabels = [
     "Top-Left", "Top-Center", "Top-Right",
     "Middle-Left", "Middle-Center", "Middle-Right",
     "Bottom-Left", "Bottom-Center", "Bottom-Right"
 ];
-
 
 function ResultCard({
   title,


### PR DESCRIPTION
The file src/app/prompt-to-prototype/page.tsx had an array of strings that was not assigned to any variable, causing a parsing error: "Expression expected".

This change assigns the array to a const variable named `moodBoardPositionalLabels`. This resolves the parsing error and makes the labels available for use in the component, specifically for titling mood board cells when a title is not explicitly provided.