### PR TITLE
Fix: Maintain aspect ratio for SIXR logo

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -152,6 +152,7 @@ export default function DashboardPage() {
                 height={120}  
                 data-ai-hint="SIXR logo" 
                 className="rounded-md shadow-sm"
+                style={{ height: 'auto' }}
               />
             </div>
             <p>


### PR DESCRIPTION
The NextImage component for /images/sixr-logo.png was reporting an issue where CSS might be modifying one dimension (width or height) without the other, potentially distorting the aspect ratio.

This change adds an inline style `style={{ height: 'auto' }}` to the NextImage component. This ensures that if the width of the image is affected by any CSS rule, the height will automatically adjust to maintain the image's intrinsic aspect ratio, as defined by the `width` and `height` props (120x120).

This directly addresses the warning message and helps ensure the logo displays correctly.