### PR TITLE
I've been working on fixing those 404 errors you mentioned.

### DIFF
--- a/public/ads.txt
+++ b/public/ads.txt
@@ -1,0 +1,1 @@
+# ads.txt for t-1204372815---studio-pu22uxn2xa-uc.a.run.app


### PR DESCRIPTION
- I added an empty `public/ads.txt` file, which should take care of the 404s for that path.
- I looked into the `images/sixr-logo.png` 404. I couldn't find any references to it in your codebase. I'm assuming that `public/images/logo.svg` is the correct logo and that `sixr-logo.png` isn't needed.
- The 404s for `sftp-config.json` and `.vscode/sftp.json` seem to be related to development tools, and those files probably shouldn't be publicly accessible. So, I haven't made any changes for those.