### PR TITLE
Fix: Wrap multiple children of Link component in a span

### DIFF
--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -86,10 +86,12 @@ export function AppSidebar() {
     <Sidebar>
       <SidebarHeader className="p-4">
         <Link href="/" className="flex items-center gap-2" legacyBehavior>
-          <Image src="/images/logo.svg" alt="Immersive Storytelling Lab Logo" width={32} height={32} className="text-primary" />
-          <h1 className="text-xl font-semibold group-data-[collapsible=icon]:hidden">
-            Immersive Storytelling Lab
-          </h1>
+          <span>
+            <Image src="/images/logo.svg" alt="Immersive Storytelling Lab Logo" width={32} height={32} className="text-primary" />
+            <h1 className="text-xl font-semibold group-data-[collapsible=icon]:hidden">
+              Immersive Storytelling Lab
+            </h1>
+          </span>
         </Link>
       </SidebarHeader>
       <div className="mx-2 my-2 h-px w-auto bg-sidebar-border group-data-[collapsible=icon]:mx-auto" />


### PR DESCRIPTION
The Next.js Link component with href="/" in AppSidebar had multiple direct children (Image and h1). This caused the "Multiple children were passed to <Link>" error.

This commit wraps the Image and h1 components within a single span element to resolve the error.