### PR TITLE
Refactor: Implement useGeneratePrototype hook

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { GeistSans } from 'geist/font/sans';
 import { GeistMono } from 'geist/font/mono';
 import './globals.css';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { SidebarProvider } from '@/components/ui/sidebar';
 import { AppSidebar } from '@/components/layout/sidebar';
 import { AppHeader } from '@/components/layout/header';
@@ -10,6 +11,9 @@ import { cn } from '@/lib/utils';
 
 const geistSans = GeistSans;
 const geistMono = GeistMono;
+
+// Create a new QueryClient instance
+const queryClient = new QueryClient();
 
 export const metadata: Metadata = {
   title: 'Immersive Storytelling Lab',
@@ -31,16 +35,18 @@ export default function RootLayout({
         )}
         suppressHydrationWarning={true}
       >
-        <SidebarProvider>
-          <AppSidebar />
-          <div className="flex flex-col flex-1 min-h-screen">
-            <AppHeader />
-            <main className="flex-1 p-4 md:p-6 lg:p-8">
-              {children}
-            </main>
-          </div>
-        </SidebarProvider>
-        <Toaster />
+        <QueryClientProvider client={queryClient}>
+          <SidebarProvider>
+            <AppSidebar />
+            <div className="flex flex-col flex-1 min-h-screen">
+              <AppHeader />
+              <main className="flex-1 p-4 md:p-6 lg:p-8">
+                {children}
+              </main>
+            </div>
+          </SidebarProvider>
+          <Toaster />
+        </QueryClientProvider>
       </body>
     </html>
   );

--- a/src/hooks/useGeneratePrototype.ts
+++ b/src/hooks/useGeneratePrototype.ts
@@ -1,0 +1,50 @@
+import { useMutation } from "@tanstack/react-query";
+
+export interface PromptInput {
+  prompt: string;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params?: Record<string, any>;
+}
+
+export interface PromptPackage {
+  inputs: PromptInput[];
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  params?: Record<string, any>;
+}
+
+export const useGeneratePrototype = () => {
+  return useMutation<string, Error, PromptPackage>(async (promptPackage) => {
+    const response = await fetch("/api/prototype/generate", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(promptPackage),
+    });
+
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const contentType = response.headers.get("content-type");
+    if (contentType?.includes("text/html")) {
+      throw new Error("Received HTML response instead of JSON");
+    }
+
+    try {
+      const data = await response.json();
+      // Assuming the API returns a JSON object with a 'url' property
+      // when successful, and the 'url' is a string.
+      // Adjust if the actual successful response structure is different.
+      if (data && typeof data.url === 'string') {
+        return data.url;
+      } else {
+        // Handle cases where the JSON does not have the expected structure
+        throw new Error("Invalid JSON response structure");
+      }
+    } catch (error) {
+      // Handle cases where response.json() fails (e.g., not valid JSON)
+      throw new Error("Failed to parse JSON response");
+    }
+  });
+};


### PR DESCRIPTION
Replaces the handleGenerate function in PromptToPrototypePage with a new `useGeneratePrototype` hook using @tanstack/react-query.

This change centralizes the fetch logic, error handling (including gracefully handling Next.js dev overlay errors), and loading states within the hook.

Key changes:
- Created `src/hooks/useGeneratePrototype.ts` with the new hook.
- Updated `src/app/prompt-to-prototype/page.tsx` to use the hook.
- Wrapped the application in `src/app/layout.tsx` with `QueryClientProvider`.

This addresses the issue of the Next.js error overlay failing to fetch source maps by improving the robustness of the data fetching logic on the page.