### PR TITLE
Refactor: Remove legacyBehavior from Next.js Link components

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { Button } from "@/components/ui/button";
@@ -128,7 +127,7 @@ export default function DashboardPage() {
                 <CardDescription className="text-base">{feature.description}</CardDescription>
               </CardContent>
               <CardFooter>
-                <Link href={feature.href} passHref legacyBehavior>
+                <Link href={feature.href}>
                   <Button variant="default" className="w-full bg-primary hover:bg-primary/90">
                     Go to {feature.title} <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>
@@ -174,4 +173,3 @@ export default function DashboardPage() {
     </div>
   );
 }
-    

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import Image from 'next/image';
@@ -85,7 +84,7 @@ export function AppSidebar() {
   return (
     <Sidebar>
       <SidebarHeader className="p-4">
-        <Link href="/" className="flex items-center gap-2" legacyBehavior>
+        <Link href="/" className="flex items-center gap-2">
           <span>
             <Image src="/images/logo.svg" alt="Immersive Storytelling Lab Logo" width={32} height={32} className="text-primary" />
             <h1 className="text-xl font-semibold group-data-[collapsible=icon]:hidden">
@@ -99,7 +98,7 @@ export function AppSidebar() {
         <SidebarMenu>
           {navItems.map((item) => (
             <SidebarMenuItem key={item.href}>
-              <Link href={item.href} passHref legacyBehavior>
+              <Link href={item.href}>
                 <SidebarMenuButton
                   className={cn(
                     pathname === item.href && 'bg-sidebar-accent text-sidebar-accent-foreground'


### PR DESCRIPTION
The `legacyBehavior` prop on Next.js `Link` components is deprecated. This commit removes `legacyBehavior` and `passHref` (where appropriate) from `Link` components in the following files:

- src/app/page.tsx
- src/components/layout/sidebar.tsx

The updates were made based on the Next.js codemod guide for `new-link`, though I had to apply the changes manually as the codemod itself did not modify the files directly.