### PR TITLE
Fix: Resolve nested <a> tag hydration error in Sidebar

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import { Button } from "@/components/ui/button";
@@ -128,7 +127,7 @@ export default function DashboardPage() {
                 <CardDescription className="text-base">{feature.description}</CardDescription>
               </CardContent>
               <CardFooter>
-                <Link href={feature.href} passHref legacyBehavior>
+                <Link href={feature.href}>
                   <Button variant="default" className="w-full bg-primary hover:bg-primary/90">
                     Go to {feature.title} <ArrowRight className="ml-2 h-4 w-4" />
                   </Button>
@@ -174,4 +173,3 @@ export default function DashboardPage() {
     </div>
   );
 }
-    

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -1,4 +1,3 @@
-
 "use client";
 
 import Image from 'next/image';
@@ -85,7 +84,7 @@ export function AppSidebar() {
   return (
     <Sidebar>
       <SidebarHeader className="p-4">
-        <Link href="/" className="flex items-center gap-2" legacyBehavior>
+        <Link href="/" className="flex items-center gap-2">
           <span>
             <Image src="/images/logo.svg" alt="Immersive Storytelling Lab Logo" width={32} height={32} className="text-primary" />
             <h1 className="text-xl font-semibold group-data-[collapsible=icon]:hidden">
@@ -99,7 +98,7 @@ export function AppSidebar() {
         <SidebarMenu>
           {navItems.map((item) => (
             <SidebarMenuItem key={item.href}>
-              <Link href={item.href} passHref legacyBehavior>
+              <Link href={item.href}>
                 <SidebarMenuButton
                   className={cn(
                     pathname === item.href && 'bg-sidebar-accent text-sidebar-accent-foreground'
@@ -107,10 +106,10 @@ export function AppSidebar() {
                   asChild
                   tooltip={{ children: item.label, side: 'right', align: 'center' }}
                 >
-                  <a>
+                  <>
                     <item.icon className="h-5 w-5" />
                     <span className="group-data-[collapsible=icon]:hidden">{item.label}</span>
-                  </a>
+                  </>
                 </SidebarMenuButton>
               </Link>
             </SidebarMenuItem>


### PR DESCRIPTION
The previous commit to remove `legacyBehavior` from `Link` components in `src/components/layout/sidebar.tsx` inadvertently caused a hydration error due to nested `<a>` tags.

This occurred because the `Link` component (without `legacyBehavior`) renders an `<a>` tag, and the child `SidebarMenuButton` component, which uses `asChild`, also had an explicit `<a>` tag as its direct child.

This commit resolves the issue by removing the explicit `<a>` tag from within the `SidebarMenuButton` component. The icon and label are now wrapped in a React Fragment (`<>...</>`) to ensure correct rendering. This allows the `Link` component's `<a>` tag to be the sole anchor, with `SidebarMenuButton`'s props correctly applied to it via `asChild`.