### PR TITLE
Fix: Explicitly define mutationFn in useGeneratePrototype

### DIFF
--- a/src/hooks/useGeneratePrototype.ts
+++ b/src/hooks/useGeneratePrototype.ts
@@ -13,7 +13,8 @@ export interface PromptPackage {
 }
 
 export const useGeneratePrototype = () => {
-  return useMutation<string, Error, PromptPackage>(async (promptPackage) => {
+  return useMutation<string, Error, PromptPackage>({
+    mutationFn: async (promptPackage) => {
     const response = await fetch("/api/prototype/generate", {
       method: "POST",
       headers: {
@@ -46,5 +47,6 @@ export const useGeneratePrototype = () => {
       // Handle cases where response.json() fails (e.g., not valid JSON)
       throw new Error("Failed to parse JSON response");
     }
+  },
   });
 };


### PR DESCRIPTION
Addresses the 'No mutationFn found' error in TanStack Query by changing the useMutation call in `src/hooks/useGeneratePrototype.ts` to use the explicit object form `{ mutationFn: async () => { ... } }` instead of the shorthand form `async () => { ... }`.

This change aims to prevent potential misinterpretations of the mutation function by TanStack Query, especially in development environments that might use tools like Turbopack, ensuring the `mutationFn` is always correctly identified.