### PR TITLE
Fix: Improve Firebase Admin SDK error handling and config clarity

### DIFF
--- a/src/app/api/prototype/generate/route.ts
+++ b/src/app/api/prototype/generate/route.ts
@@ -176,12 +176,10 @@ export async function POST(req: NextRequest): Promise<NextResponse> {
     if (db) {
       try {
         await db.collection('promptPackages').doc(newPromptPackage.id).set(newPromptPackage);
-      } catch (firestoreError: any) { // Changed unknown to any
-        console.error('Failed to save PromptPackage to Firestore:', firestoreError);
-        // Decide if this is critical. The client will still get the package, but it won't be saved.
-        // Could return a specific error or a warning. For now, log and continue.
-        // Potentially, you might want to return a 500 error here as the backend state is inconsistent.
-        return NextResponse.json({ error: 'Failed to save data to database.', details: firestoreError.message }, { status: 500 });
+      } catch (firestoreError: unknown) {
+        const message = firestoreError instanceof Error ? firestoreError.message : 'Unknown Firestore error';
+        console.error('Failed to save PromptPackage to Firestore:', message, firestoreError); // Log the original error too
+        return NextResponse.json({ error: 'Failed to save data to database.', details: message }, { status: 500 });
       }
     } else {
       console.warn('Firestore is not initialized. PromptPackage was not saved.');

--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -15,6 +15,15 @@ let storage: admin.storage.Storage;
 let app: admin.app.App;
 
 if (!admin.apps.length) {
+  // Add this block for detailed logging in non-production environments
+  if (process.env.NODE_ENV !== 'production') {
+    console.log('Firebase Admin SDK Initialization Check (Non-Production):');
+    console.log(`  FIREBASE_PROJECT_ID: ${FIREBASE_PROJECT_ID ? 'Present' : 'MISSING'}`);
+    console.log(`  FIREBASE_CLIENT_EMAIL: ${FIREBASE_CLIENT_EMAIL ? 'Present' : 'MISSING'}`);
+    console.log(`  FIREBASE_PRIVATE_KEY: ${process.env.FIREBASE_PRIVATE_KEY ? 'Present (not displaying value)' : 'MISSING'}`); // Check original env var for presence
+    console.log(`  FIREBASE_STORAGE_BUCKET: ${FIREBASE_STORAGE_BUCKET ? 'Present' : 'MISSING'}`);
+  }
+
   if (FIREBASE_PROJECT_ID && FIREBASE_CLIENT_EMAIL && FIREBASE_PRIVATE_KEY && FIREBASE_STORAGE_BUCKET) {
     try {
       app = admin.initializeApp({
@@ -27,9 +36,10 @@ if (!admin.apps.length) {
       });
       console.log('Firebase Admin SDK initialized successfully.');
     } catch (error: unknown) {
-      console.error('Firebase Admin SDK initialization error:', error instanceof Error ? error.message : 'An unknown error occurred');
-      // Optionally, throw the error or handle it as per your application's needs
-      // throw new Error(`Firebase Admin SDK initialization failed: ${error.message}`);
+      const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred during Firebase Admin SDK initialization';
+      console.error('Firebase Admin SDK initialization error:', errorMessage);
+      // Re-throw the error to make the failure explicit
+      throw new Error(`Firebase Admin SDK initialization failed: ${errorMessage}`);
     }
   } else {
     console.warn(


### PR DESCRIPTION
This commit introduces several improvements to make Firebase Admin SDK initialization more robust and easier to debug:

1.  **Explicit Initialization Errors:** Errors encountered during `admin.initializeApp()` in `src/lib/firebase/admin.ts` are now re-thrown. This ensures that if Firebase Admin fails to initialize (e.g., due to incorrect credentials or missing environment variables), the application startup will fail explicitly, preventing it from running in a partially initialized and potentially erroneous state.

2.  **Refined Error Typing:** In `src/app/api/prototype/generate/route.ts`, the catch block for Firestore save operations now correctly types `firestoreError` as `unknown` (from `any`) and uses an `instanceof Error` check for safer access to the error message. The original error object is also logged for better debugging.

3.  **Enhanced Environment Variable Logging (Dev Only):** Added detailed logging in `src/lib/firebase/admin.ts` that, in non-production environments, lists each required Firebase environment variable (`FIREBASE_PROJECT_ID`, `FIREBASE_CLIENT_EMAIL`, `FIREBASE_PRIVATE_KEY`, `FIREBASE_STORAGE_BUCKET`) and indicates whether it's present or missing. This will significantly aid developers in diagnosing setup issues locally without exposing sensitive information in production logs.

These changes aim to address potential 500 errors caused by Firebase initialization problems by making such issues more visible and providing clearer guidance for configuration.