### PR TITLE
feat: Add SIXR logo to homepage and sidebar

### DIFF
--- a/public/images/sixr-logo.png
+++ b/public/images/sixr-logo.png
@@ -1,0 +1,1 @@
+This is a placeholder for sixr-logo.png.

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -83,11 +83,14 @@ export function AppSidebar() {
 
   return (
     <Sidebar>
-      <SidebarHeader className="p-4">
-        <Link href="/" className="flex items-center gap-2">
-          <span>
+      <SidebarHeader className="p-4 flex flex-col items-center">
+        <Link href="/" className="flex flex-col items-center gap-2 mb-4">
+          {/* SIXR Logo */}
+          <Image src="/images/sixr-logo.png" alt="SIXR Logo" width={48} height={48} />
+          {/* Original App Logo and Title */}
+          <span className="flex items-center gap-2">
             <Image src="/images/logo.svg" alt="Immersive Storytelling Lab Logo" width={32} height={32} className="text-primary" />
-            <h1 className="text-xl font-semibold group-data-[collapsible=icon]:hidden">
+            <h1 className="text-lg font-semibold group-data-[collapsible=icon]:hidden">
               Immersive Storytelling Lab
             </h1>
           </span>


### PR DESCRIPTION
- Added placeholder for `public/images/sixr-logo.png`.
- Verified SIXR logo presence on the homepage (`src/app/page.tsx`).
- Added SIXR logo to the sidebar (`src/components/layout/sidebar.tsx`), linking to the homepage.