### PR TITLE
fix: Correct SIXR logo placement in sidebar

### DIFF
--- a/public/images/sixr-logo.png
+++ b/public/images/sixr-logo.png
@@ -1,0 +1,1 @@
+This is a placeholder for sixr-logo.png.

--- a/src/components/layout/sidebar.tsx
+++ b/src/components/layout/sidebar.tsx
@@ -83,11 +83,12 @@ export function AppSidebar() {
 
   return (
     <Sidebar>
-      <SidebarHeader className="p-4">
-        <Link href="/" className="flex items-center gap-2">
-          <span>
-            <Image src="/images/logo.svg" alt="Immersive Storytelling Lab Logo" width={32} height={32} className="text-primary" />
-            <h1 className="text-xl font-semibold group-data-[collapsible=icon]:hidden">
+      <SidebarHeader className="p-4 flex flex-col items-center">
+        <Link href="/" className="flex flex-col items-center gap-2 mb-4">
+          {/* Text and new SIXR Logo */}
+          <span className="flex items-center gap-2">
+            <Image src="/images/sixr-logo.png" alt="SIXR Logo" width={32} height={32} className="text-primary" />
+            <h1 className="text-lg font-semibold group-data-[collapsible=icon]:hidden">
               Immersive Storytelling Lab
             </h1>
           </span>


### PR DESCRIPTION
- Replaced the original logo associated with "Immersive Storytelling Lab" text in the sidebar with the SIXR logo (`/images/sixr-logo.png`).
- Ensured the "Immersive Storytelling Lab" text is retained.
- Removed any duplicate SIXR logos from the sidebar.
- The SIXR logo used is a placeholder. The actual `sixr-logo.png` should be added to `public/images/`.