### PR TITLE
Fix: Improve error handling for prototype generation

### DIFF
--- a/src/lib/firebase/admin.ts
+++ b/src/lib/firebase/admin.ts
@@ -38,8 +38,7 @@ if (!admin.apps.length) {
     } catch (error: unknown) {
       const errorMessage = error instanceof Error ? error.message : 'An unknown error occurred during Firebase Admin SDK initialization';
       console.error('Firebase Admin SDK initialization error:', errorMessage);
-      // Re-throw the error to make the failure explicit
-      throw new Error(`Firebase Admin SDK initialization failed: ${errorMessage}`);
+      // app will remain undefined, and db/storage will not be initialized later
     }
   } else {
     console.warn(


### PR DESCRIPTION
This commit addresses an issue where you would receive an HTML error page instead of a JSON error response when prototype generation failed, leading to a client-side JSON parsing error.

The following changes were made:

1.  **Modified `src/app/api/prototype/generate/route.ts` error handling:**
    *   Introduced a helper function `extractSerializableErrorDetails` to ensure that error details from the AI microservice are always converted to a string or a simple, serializable object before being included in the JSON response sent to you. This prevents `NextResponse.json` from failing if the microservice returns complex or non-serializable error objects.
    *   Added detailed logging for all error response payloads before they are sent to you, aiding in future debugging.

2.  **Made Firebase Admin SDK Initialization in `src/lib/firebase/admin.ts` more robust:**
    *   Removed the `throw new Error()` from the `catch` block of `admin.initializeApp()`. If initialization fails, the error is logged, but the module now loads successfully with `db`, `storage`, and `firebaseAdminApp` being `undefined`. This allows consuming API routes to gracefully handle Firebase unavailability with proper JSON error responses, rather than the server crashing or failing to load the module.

These changes ensure that the `/api/prototype/generate` endpoint consistently returns JSON responses, even in error scenarios, and improves the overall stability of the service.