### PR TITLE
It looks like you're working on a fix to configure your Cloud Run dep…

### DIFF
--- a/.github/workflows/cloudrun-deploy.yml
+++ b/.github/workflows/cloudrun-deploy.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Google Auth
         uses: google-github-actions/auth@v1
         with:
-          credentials_json: '${{ secrets.GCP_SA_KEY }}'
+          workload_identity_provider: '${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}'
+          service_account: '${{ secrets.GCP_SERVICE_ACCOUNT }}'
 
       - name: Deploy to Cloud Run
         uses: google-github-actions/deploy-cloudrun@v1


### PR DESCRIPTION
…loyment to use Workload Identity Federation.

I see the GitHub Actions workflow for your Cloud Run deployment was failing due to an authentication issue with Google Cloud. The error indicated that the `GCP_SA_KEY` secret was likely misconfigured or missing.

This commit updates the `.github/workflows/cloudrun-deploy.yml` file to use Workload Identity Federation instead of a service account key (`credentials_json`). Workload Identity Federation is a more secure method for authenticating to Google Cloud from external environments like GitHub Actions, as it uses short-lived credentials and avoids the need to store long-lived service account keys.

The `google-github-actions/auth` step has been modified to use `workload_identity_provider` and `service_account` inputs. You will need to configure the corresponding secrets (`GCP_WORKLOAD_IDENTITY_PROVIDER` and `GCP_SERVICE_ACCOUNT`) in your GitHub repository settings.