### PR TITLE
Fix: Update Dockerfile path in workflow

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build the Docker image
-      run: docker build . --file Dockerfile --tag my-image-name:$(date +%s)
+      run: docker build . --file collaboration-service/Dockerfile --tag my-image-name:$(date +%s)


### PR DESCRIPTION
The Docker build was failing because the workflow was looking for the Dockerfile at the repository root.

This commit updates the `.github/workflows/docker-image.yml` file to point to the correct Dockerfile location at `collaboration-service/Dockerfile`.