### PR TITLE
Fix: Add alt text to storyboard panel images for accessibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## [1.1.1] - 2025-06-17
+### Fixed
+- **Accessibility Improvement for Storyboard Images**:
+  - **Finding**: AI-generated storyboard panel images were missing `alt` text, negatively impacting accessibility for users relying on screen readers or assistive technologies.
+  - **Fix**: Modified the AI storyboard generation flow (`ai-microservice/src/flows/storyboard-generator-flow.ts`) to populate the `alt` attribute of each panel image. The `alt` text is now derived from the AI-generated textual description of the panel's visual content. This ensures that all storyboard images have meaningful alternative text. Shared types in `src/lib/ai-types.ts` were also updated for consistency.
+  - **Verification**: Changes were verified by inspecting the code flow from the AI service, through the Next.js API, to the frontend components. The `alt` field is correctly added to the `Panel` data structure and utilized by the `StoryboardGridPanel.tsx` component.
+  - **Note**: A broader accessibility audit for color contrast and keyboard navigation across the application is recommended as a next step.
+
 # ISL.SIXR.tv Documentation Changelog
 
 ## [1.1.0] - 2025-06-16

--- a/ai-microservice/src/flows/storyboard-generator-flow.ts
+++ b/ai-microservice/src/flows/storyboard-generator-flow.ts
@@ -18,6 +18,7 @@ const StoryboardPanelSchema = z.object({
 
 const StoryboardPanelWithImageSchema = StoryboardPanelSchema.extend({
   imageDataUri: z.string().describe("The generated image for this panel, as a data URI. Expected format: 'data:image/png;base64,<encoded_data>'."),
+  alt: z.string().describe("Descriptive alt text for the panel image, derived from its visual description."),
 });
 
 const StoryboardGeneratorInputSchema = z.object({
@@ -116,12 +117,14 @@ const storyboardGeneratorFlow = ai.defineFlow(
           return {
             ...panelTextData,
             imageDataUri: media.url,
+            alt: panelTextData.description,
           };
         } else {
            console.warn(`Image generation failed for panel ${panelTextData.panelNumber}. No media URL returned.`);
           return {
             ...panelTextData,
             imageDataUri: `https://placehold.co/512x384.png?text=Image+Gen+Failed+P${panelTextData.panelNumber}`,
+            alt: panelTextData.description, // Also add alt text for placeholder
           };
         }
       } catch (error) {
@@ -129,6 +132,7 @@ const storyboardGeneratorFlow = ai.defineFlow(
         return {
           ...panelTextData,
           imageDataUri: `https://placehold.co/512x384.png?text=Image+Error+P${panelTextData.panelNumber}`,
+          alt: panelTextData.description, // And for error placeholder
         };
       }
     });

--- a/src/lib/ai-types.ts
+++ b/src/lib/ai-types.ts
@@ -82,6 +82,7 @@ export type StoryboardPanel = z.infer<typeof StoryboardPanelSchema>;
 
 export const StoryboardPanelWithImageSchema = StoryboardPanelSchema.extend({
   imageDataUri: z.string().describe("The generated image for this panel, as a data URI. Expected format: 'data:image/png;base64,<encoded_data>'."),
+  alt: z.string().describe("Descriptive alt text for the panel image, derived from its visual description."),
 });
 export type StoryboardPanelWithImage = z.infer<typeof StoryboardPanelWithImageSchema>;
 


### PR DESCRIPTION
AI-generated storyboard panel images were missing descriptive alt text, hindering accessibility for you if you rely on screen readers.

This commit addresses the issue by:
1. Modifying the `storyboardGeneratorFlow` in the AI microservice (`ai-microservice/src/flows/storyboard-generator-flow.ts`) to populate an `alt` field for each panel. The alt text is derived from the AI-generated textual description of the panel's visual content.
2. Updating the shared `StoryboardPanelWithImageSchema` in `src/lib/ai-types.ts` to include the new `alt` field for type consistency across the backend and frontend.
3. Verifying that the Next.js API route (`src/app/api/storyboard-studio/generate/route.ts`) correctly passes this `alt` text through to the frontend.
4. Confirming that the frontend component `StoryboardGridPanel.tsx` already utilizes the `panel.alt` field, so it will now display the populated alt text.

These changes ensure that all storyboard images you see have meaningful alt text, improving compliance with accessibility standards (WCAG). A broader accessibility audit for color contrast and keyboard navigation is noted as a recommended next step in the CHANGELOG.