### PR TITLE
Refactor: Optimize mood board image handling in Prompt-to-Prototype

### DIFF
--- a/ai-microservice/src/flows/prompt-to-prototype.test.ts
+++ b/ai-microservice/src/flows/prompt-to-prototype.test.ts
@@ -1,0 +1,225 @@
+import { promptToPrototypeFlow, PromptToPrototypeInputSchema } from './prompt-to-prototype';
+import { ai } from '../genkit';
+import { uploadImageToStorage } from '../storage';
+import { v4 as uuidv4 } from 'uuid'; // Import v4 directly
+
+jest.mock('../genkit', () => ({
+  ai: {
+    definePrompt: jest.fn(), // Will be mocked in beforeEach
+    generate: jest.fn(), // To be configured per test
+    // Define defineFlow to execute the actual flow function for testing
+    // This allows us to test the flow's logic directly
+    defineFlow: jest.fn((config, fn) => {
+        if (typeof fn !== 'function') {
+            throw new Error('Flow function not provided to defineFlow mock');
+        }
+        return fn; // Return the actual flow function
+    }),
+  },
+}));
+
+jest.mock('../storage', () => ({
+  uploadImageToStorage: jest.fn(),
+}));
+
+jest.mock('uuid', () => ({
+  v4: jest.fn(() => 'mock-uuid-for-image'),
+}));
+
+describe('promptToPrototypeFlow - Image Handling', () => {
+  // Default input for most tests, customize as needed
+  const mockBaseInput: ReturnType<typeof PromptToPrototypeInputSchema.parse> = {
+    prompt: 'A futuristic cityscape',
+  };
+
+  // Mock text output that the text generation part of the flow would produce
+  const mockTextOutputFromAI = {
+    loglines: [{ tone: 'dramatic', text: 'In a city of tomorrow...' }],
+    moodBoardCells: Array(9).fill(null).map((_, i) => ({ title: `Theme ${i + 1}`, description: `Description for theme ${i + 1}` })),
+    shotList: '1,50mm,Pan Right,Wide shot of skyline',
+    proxyClipAnimaticDescription: 'A quick fly-through of the city.',
+    pitchSummary: 'A stunning vision of the future.',
+    // moodBoardImage is handled by image generation, so not included here
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Setup default mock for the text generation prompt (textGenerationPrompt)
+    // This mock simulates the behavior of the text generation part of the flow
+    (ai.definePrompt as jest.Mock).mockImplementation((promptConfig) => {
+      // The function returned by definePrompt is the one called within the flow
+      return jest.fn().mockResolvedValue({ output: mockTextOutputFromAI });
+    });
+  });
+
+  test('1. AI generates data URI, upload to storage succeeds', async () => {
+    const testInput = { ...mockBaseInput };
+    const dataUri = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAUA'; // Minimal valid base64 PNG
+    const fakeGcsUrl = 'https://fake-storage.googleapis.com/moodboard_output_mock-uuid-for-image.png';
+
+    (ai.generate as jest.Mock).mockResolvedValue({
+      media: { url: dataUri },
+    });
+    (uploadImageToStorage as jest.Mock).mockResolvedValue(fakeGcsUrl);
+
+    const result = await promptToPrototypeFlow(testInput);
+
+    expect(result.moodBoardImage).toBe(fakeGcsUrl);
+    expect(uploadImageToStorage).toHaveBeenCalledTimes(1);
+    expect(uploadImageToStorage).toHaveBeenCalledWith(expect.objectContaining({
+      buffer: expect.any(Buffer),
+      mimeType: 'image/png',
+      extension: 'png',
+      userId: "ai_prototype_system",
+      packageId: 'mock-uuid-for-image',
+      fileNamePrefix: "moodboard_output_",
+    }));
+    expect(uuidv4).toHaveBeenCalledTimes(1);
+  });
+
+  test('2. AI generates data URI, upload to storage fails', async () => {
+    const testInput = { ...mockBaseInput };
+    const dataUri = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQEASABIAAD'; // Minimal valid base64 JPEG
+
+    (ai.generate as jest.Mock).mockResolvedValue({
+      media: { url: dataUri },
+    });
+    (uploadImageToStorage as jest.Mock).mockRejectedValue(new Error('Storage unavailable'));
+
+    const result = await promptToPrototypeFlow(testInput);
+
+    expect(result.moodBoardImage).toBe("https://placehold.co/600x400.png?text=Image+Storage+Failed");
+    expect(uploadImageToStorage).toHaveBeenCalledTimes(1);
+    expect(uploadImageToStorage).toHaveBeenCalledWith(expect.objectContaining({
+        mimeType: 'image/jpeg',
+        extension: 'jpeg',
+    }));
+    expect(uuidv4).toHaveBeenCalledTimes(1);
+  });
+
+  test('3. AI image generation fails (returns no URL)', async () => {
+    const testInput = { ...mockBaseInput };
+
+    (ai.generate as jest.Mock).mockResolvedValue({
+      media: undefined, // Simulate failure like media object being undefined
+    });
+
+    const result = await promptToPrototypeFlow(testInput);
+
+    expect(result.moodBoardImage).toBe("https://placehold.co/600x400.png?text=Image+Gen+Failed");
+    expect(uploadImageToStorage).not.toHaveBeenCalled();
+    expect(uuidv4).not.toHaveBeenCalled();
+  });
+
+  test('3b. AI image generation fails (media.url is undefined)', async () => {
+    const testInput = { ...mockBaseInput };
+
+    (ai.generate as jest.Mock).mockResolvedValue({
+      media: { url: undefined }, // Simulate failure with undefined URL
+    });
+
+    const result = await promptToPrototypeFlow(testInput);
+
+    expect(result.moodBoardImage).toBe("https://placehold.co/600x400.png?text=Image+Gen+Failed");
+    expect(uploadImageToStorage).not.toHaveBeenCalled();
+    expect(uuidv4).not.toHaveBeenCalled();
+  });
+
+
+  test('4. AI generates a non-data URI (e.g., already a GCS URL)', async () => {
+    const testInput = { ...mockBaseInput };
+    const preSignedUrl = 'https://already-a-gcs-url.com/image.png';
+
+    (ai.generate as jest.Mock).mockResolvedValue({
+      media: { url: preSignedUrl },
+    });
+
+    const result = await promptToPrototypeFlow(testInput);
+
+    expect(result.moodBoardImage).toBe(preSignedUrl);
+    expect(uploadImageToStorage).not.toHaveBeenCalled();
+    expect(uuidv4).not.toHaveBeenCalled();
+  });
+
+  test('5. Input imageDataUri is present, AI generates data URI, upload succeeds', async () => {
+    const testInput: ReturnType<typeof PromptToPrototypeInputSchema.parse> = {
+      ...mockBaseInput,
+      imageDataUri: 'data:image/gif;base64,R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=', // User provided image
+    };
+    const aiGeneratedDataUri = 'data:image/webp;base64,UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA=='; // Minimal webp
+    const fakeGcsUrl = 'https://fake-storage.googleapis.com/moodboard_output_mock-uuid-for-image.webp';
+
+    (ai.generate as jest.Mock).mockResolvedValue({
+      media: { url: aiGeneratedDataUri },
+    });
+    (uploadImageToStorage as jest.Mock).mockResolvedValue(fakeGcsUrl);
+
+    const result = await promptToPrototypeFlow(testInput);
+
+    expect(result.moodBoardImage).toBe(fakeGcsUrl);
+    expect(uploadImageToStorage).toHaveBeenCalledTimes(1);
+    expect(uploadImageToStorage).toHaveBeenCalledWith(expect.objectContaining({
+      buffer: expect.any(Buffer),
+      mimeType: 'image/webp',
+      extension: 'webp',
+      packageId: 'mock-uuid-for-image',
+    }));
+    // Check that the input imageDataUri was passed to ai.generate
+    expect(ai.generate).toHaveBeenCalledWith(expect.objectContaining({
+        prompt: expect.arrayContaining([
+            expect.objectContaining({ media: { url: testInput.imageDataUri } }),
+            expect.objectContaining({ text: expect.any(String) })
+        ])
+    }));
+    expect(uuidv4).toHaveBeenCalledTimes(1);
+  });
+
+  test('Should correctly parse various image mime types for data URIs', async () => {
+    const testCases = [
+      { mime: 'image/png', ext: 'png', data: 'iVBORw0KGgoAAAANSUhEUgAAAAUA' },
+      { mime: 'image/jpeg', ext: 'jpeg', data: '/9j/4AAQSkZJRgABAQEASABIAAD' },
+      { mime: 'image/gif', ext: 'gif', data: 'R0lGODlhAQABAIAAAAUEBAAAACwAAAAAAQABAAACAkQBADs=' },
+      { mime: 'image/webp', ext: 'webp', data: 'UklGRhoAAABXRUJQVlA4TA0AAAAvAAAAEAcQERGIiP4HAA==' },
+      { mime: 'image/svg+xml', ext: 'svg+xml', data: 'PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjwvc3ZnPg==' }, // Basic SVG
+    ];
+
+    for (const tc of testCases) {
+      const dataUri = `data:${tc.mime};base64,${tc.data}`;
+      const fakeGcsUrl = `https://fake-storage.googleapis.com/moodboard_output_mock-uuid-for-image.${tc.ext}`;
+
+      (ai.generate as jest.Mock).mockResolvedValue({ media: { url: dataUri } });
+      (uploadImageToStorage as jest.Mock).mockResolvedValue(fakeGcsUrl);
+      // Reset uuid mock for each iteration if it's specific to extension, though here it's filename prefix
+      (uuidv4 as jest.Mock).mockReturnValue(`mock-uuid-for-image`);
+
+
+      const result = await promptToPrototypeFlow({ ...mockBaseInput });
+
+      expect(result.moodBoardImage).toBe(fakeGcsUrl);
+      expect(uploadImageToStorage).toHaveBeenCalledWith(expect.objectContaining({
+        mimeType: tc.mime,
+        extension: tc.ext,
+      }));
+      // Clear mock calls for next iteration, specifically for uploadImageToStorage and uuid
+      (uploadImageToStorage as jest.Mock).mockClear();
+      (uuidv4 as jest.Mock).mockClear();
+    }
+  });
+
+  test('Should use placeholder if data URI parsing fails (e.g. malformed URI)', async () => {
+    const testInput = { ...mockBaseInput };
+    const malformedDataUri = 'data:imagepngbase64,iVBORw0KGgoAAAANSUhEUgAAAAUA'; // Missing slash and semicolon
+
+    (ai.generate as jest.Mock).mockResolvedValue({
+      media: { url: malformedDataUri },
+    });
+
+    const result = await promptToPrototypeFlow(testInput);
+
+    expect(result.moodBoardImage).toBe("https://placehold.co/600x400.png?text=Image+Parse+Failed");
+    expect(uploadImageToStorage).not.toHaveBeenCalled();
+    expect(uuidv4).not.toHaveBeenCalled(); // uuid not called as upload is skipped
+  });
+
+});

--- a/benchmarking/BENCHMARK_RESULTS_V2_IMAGE_HANDLING_IMPROVEMENT.md
+++ b/benchmarking/BENCHMARK_RESULTS_V2_IMAGE_HANDLING_IMPROVEMENT.md
@@ -1,0 +1,66 @@
+# AI Feature Benchmark Results - V2 (Conceptual: Image Handling Improvement)
+
+Date: 2025-06-20
+Improvement Focus: Optimized image handling in the `promptToPrototype` flow.
+Related Issue: MLBench-B (Implement one improvement based on benchmark findings)
+Previous Benchmark: `BENCHMARK_RESULTS_V1.md`
+
+## 1. Description of Change
+
+The `promptToPrototype` flow in `ai-microservice/src/flows/prompt-to-prototype.ts` was modified to improve the handling of AI-generated mood board images.
+
+Previously, if the AI model generated a mood board image as a base64 data URI, this data URI was returned directly in the `moodBoardImage` field of the output. This could lead to large data URIs being stored in Firestore, causing database bloat and slower client-side retrieval.
+
+The implemented change is as follows:
+- After the AI generates the `moodBoardImage`:
+  - If the image is a base64 data URI, it is now uploaded to Firebase Cloud Storage.
+  - The `moodBoardImage` field in the output is then populated with the resulting GCS URL.
+  - If the upload to GCS fails, the `moodBoardImage` field is set to a specific placeholder: `https://placehold.co/600x400.png?text=Image+Storage+Failed`.
+  - If the AI initially fails to generate an image, the placeholder remains `https://placehold.co/600x400.png?text=Image+Gen+Failed`.
+  - If the AI returns a non-data URI (e.g., already a GCS URL), that URL is used directly without attempting re-upload.
+
+Unit tests have been added in `ai-microservice/src/flows/prompt-to-prototype.test.ts` to cover these new logic paths.
+
+## 2. Conceptual Benchmark Impact Assessment
+
+The most recent full benchmark run (`benchmark_results_2025-06-20T06-20-07.555Z.json`) failed due to service unavailability. Therefore, a direct before/after comparison with a live benchmark run for this specific change is not available at this moment. The following assessment is based on the `BENCHMARK_RESULTS_V1.md` baseline and the expected effects of the implemented change.
+
+### 2.1. `promptToPrototype` Feature
+
+**Targeted Aspects**:
+*   Efficiency of `moodBoardImage` storage and retrieval.
+*   Reliability and clarity of the `moodBoardImage` URL.
+*   Qualitative score for `moodBoardImage`.
+*   Potential impact on flow latency.
+
+**Expected Outcomes**:
+
+*   **`moodBoardImage` URL Format**:
+    *   **Before (V1)**: Could be a base64 data URI or a placeholder.
+    *   **After (Conceptual V2)**: Will be a GCS URL for successfully AI-generated and stored images, or one of two specific placeholders (`Image+Gen+Failed` or `Image+Storage+Failed`). This improves consistency and actionability of the URL.
+
+*   **Qualitative Score for `moodBoardImage` (Scale 1-5)**:
+    *   **Baseline (V1, excluding input error sample `prompt_005`):** Average ~3.0.
+    *   **Expected (Conceptual V2):** Average ~3.5 for successfully generated and stored images. This modest improvement is anticipated due to more robust handling, clearer failure states, and elimination of potentially problematic large data URIs being passed to clients. The AI's core image generation quality is assumed constant.
+
+*   **Response Time (Latency)**:
+    *   **Baseline (V1 Average):** 2038 ms.
+    *   **Expected (Conceptual V2):** A potential slight increase in average latency (e.g., +100-500ms) for cases where the AI generates a data URI, due to the added GCS upload step. This is a trade-off for improved storage and client performance.
+
+*   **Storage Efficiency (Not directly measured by `run_benchmarks.js`)**:
+    *   **Before (V1)**: Potentially large base64 data URIs stored in Firestore.
+    *   **After (Conceptual V2)**: Significant reduction in Firestore document size for `promptToPrototype` outputs, as large images are replaced by short GCS URLs. This improves database health and reduces costs.
+
+*   **Client-Side Performance (Not directly measured by `run_benchmarks.js`)**:
+    *   **Before (V1)**: Clients might download and process large base64 data URIs.
+    *   **After (Conceptual V2)**: Clients will download smaller payloads and load images from GCS URLs, which is generally more efficient.
+
+*   **Success Rate (HTTP 200 & Completeness Check Pass)**:
+    *   **Baseline (V1):** 100%.
+    *   **Expected (Conceptual V2):** Expected to remain 100%. The change should not affect the basic completeness check (field presence) or HTTP success, assuming GCS uploads are generally reliable or fall back to the placeholder correctly.
+
+## 3. Next Steps
+
+*   Ensure the AI microservice is reliably accessible.
+*   Perform a full benchmark run using `benchmarking/run_benchmarks.js` to obtain actual "after" metrics for this change and validate the conceptual assessment.
+*   Update this document with the results of the actual benchmark run when available.


### PR DESCRIPTION
I've implemented an improvement to the Prompt-to-Prototype flow (`ai-microservice/src/flows/prompt-to-prototype.ts`) to optimize how AI-generated mood board images are handled.

Key changes:
- If an AI generates a mood board image as a base64 data URI, I will now upload this image to Firebase Cloud Storage. The `moodBoardImage` field in the output will be updated with the GCS URL.
- If the GCS upload fails, I will set `moodBoardImage` to a specific placeholder: `https://placehold.co/600x400.png?text=Image+Storage+Failed`.
- If the AI initially fails to generate an image, the placeholder will remain `https://placehold.co/600x400.png?text=Image+Gen+Failed`.
- I will use non-data URIs returned by the AI directly.

This change addresses the issue of potentially storing large base64 data URIs in Firestore, which can cause database bloat and reduce your client-side performance.

Testing:
- I've added new unit tests in `ai-microservice/src/flows/prompt-to-prototype.test.ts` to cover various scenarios, including successful uploads, upload failures, AI generation failures, and handling of non-data URIs.

Benchmark Impact (Conceptual):
- This is documented in `benchmarking/BENCHMARK_RESULTS_V2_IMAGE_HANDLING_IMPROVEMENT.md`.
- I expect improved storage efficiency, more reliable `moodBoardImage` URLs, and potentially faster client-side image loading for you. A slight increase in `promptToPrototype` latency may occur due to the added GCS upload step.