### PR TITLE
feat: Add dialogue tone analysis to Script Analyzer

### DIFF
--- a/ai-microservice/index.test.js
+++ b/ai-microservice/index.test.js
@@ -74,7 +74,7 @@ describe('AI Microservice API Endpoints', () => {
     });
 
     it('should return 200 and analysis results for valid input', async () => {
-      const mockAnalysisOutput = { analysis: 'Great script!', suggestions: [] };
+      const mockAnalysisOutput = { analysis: 'Great script!', suggestions: [], dialogueIssues: 0 };
       analyzeScript.mockResolvedValue(mockAnalysisOutput);
       // Assuming jest.setup.js correctly mocks admin.firestore().collection().doc().set chain
       // If 'set' is not a function, this specific test will fail, indicating a setup issue.
@@ -83,7 +83,7 @@ describe('AI Microservice API Endpoints', () => {
       const response = await request(app).post('/analyzeScript').set('Authorization', 'Bearer valid-token').send(validScriptInput);
       expect(response.status).toBe(200);
       expect(response.body.id).toBe('mock-uuid-v4');
-      expect(admin.firestore().collection('scriptAnalyses').doc('mock-uuid-v4').set).toHaveBeenCalled();
+      expect(admin.firestore().collection('scriptAnalyses').doc('mock-uuid-v4').set).toHaveBeenCalledWith(expect.objectContaining(mockAnalysisOutput));
     });
 
     it('should return 500 if AI flow fails', async () => {

--- a/ai-microservice/src/flows/ai-script-analyzer.ts
+++ b/ai-microservice/src/flows/ai-script-analyzer.ts
@@ -32,6 +32,7 @@ const AnalyzeScriptOutputSchema = z.object({
       improvement: z.string().describe('A suggestion for improving the section.'),
     })
   ).describe('A list of specific suggestions for improving the script.'),
+  dialogueIssues: z.number().optional().describe('The number of dialogue issues found in the script.'),
 });
 export type AnalyzeScriptOutput = z.infer<typeof AnalyzeScriptOutputSchema>;
 
@@ -51,13 +52,15 @@ Script:
 {{{script}}}
 
 Identify any sections that are unclear, off-tone, or inconsistent, and suggest specific improvements.
+Also, analyze the dialogue for unnatural sentences. For example, a long series of statements without any questions might be considered unnatural.
+Count the number of such dialogue issues and include it in the 'dialogueIssues' field of your response.
 
 For each suggestion, provide:
 - 'section': The *exact, verbatim text* of the script segment you are addressing. This text is CRITICAL for the 'Apply Suggestion' feature and MUST be an exact quote from the original script. Do NOT paraphrase or summarize this section. Do NOT add your own surrounding quotation marks to this 'section' field unless those quotation marks are part of the original script segment itself. If the problematic text is common, try to make your quoted 'section' distinctive enough if possible.
 - 'issue': A clear description of the issue identified in that section.
 - 'improvement': A specific suggestion for how to improve that section.
 
-Ensure the overall output is a detailed analysis and a list of specific suggestions for improvement.
+Ensure the overall output is a detailed analysis, a list of specific suggestions for improvement, and the count of dialogue issues.
 Follow the schema documentation provided in the AnalyzeScriptOutputSchema for how to format your response.
 `,
 });


### PR DESCRIPTION
Extends the AI Script Analyzer to include dialogue tone analysis.

- Adds a `dialogueIssues` field to the output schema, indicating the number of unnatural dialogue instances found (e.g., sentences without questions).
- Updates the AI prompt to perform this analysis and populate the new field.
- Modifies existing tests to reflect the schema change.