### PR TITLE
feat: Implement client auth, token expiry handling, and mock 2FA flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Firebase Project Configuration (Client-Side)
+# These are exposed to the browser and should be prefixed with NEXT_PUBLIC_
+NEXT_PUBLIC_FIREBASE_API_KEY="your-api-key"
+NEXT_PUBLIC_FIREBASE_AUTH_DOMAIN="your-auth-domain"
+NEXT_PUBLIC_FIREBASE_PROJECT_ID="your-project-id"
+NEXT_PUBLIC_FIREBASE_STORAGE_BUCKET="your-storage-bucket"
+NEXT_PUBLIC_FIREBASE_MESSAGING_SENDER_ID="your-messaging-sender-id"
+NEXT_PUBLIC_FIREBASE_APP_ID="your-app-id"
+NEXT_PUBLIC_FIREBASE_MEASUREMENT_ID="your-measurement-id" # Optional
+
+# Firebase Admin Configuration (Server-Side)
+# These are used in server environments (e.g., API routes, Firebase Functions)
+# DO NOT expose these to the client.
+FIREBASE_PROJECT_ID="your-project-id"
+FIREBASE_CLIENT_EMAIL="your-firebase-admin-sdk-client-email"
+FIREBASE_PRIVATE_KEY="your-firebase-admin-sdk-private-key" # Ensure newlines are escaped (e.g. \n) if storing in a single line
+FIREBASE_STORAGE_BUCKET="your-project-id.appspot.com"
+
+# Genkit Configuration
+GENKIT_ENV="dev" # "dev" or "prod"
+GOOGLE_API_KEY="your-google-api-key-for-genkit" # If using Google AI models with Genkit
+
+# Feature Flags
+NEXT_PUBLIC_ENABLE_CREATOR_2FA=false # Toggle for Creator Two-Factor Authentication

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -9,6 +9,7 @@ import { AppSidebar } from '@/components/layout/sidebar';
 import { AppHeader } from '@/components/layout/header';
 import { Toaster } from "@/components/ui/toaster";
 import { cn } from '@/lib/utils';
+import { AuthProvider } from '@/contexts/AuthContext'; // Import AuthProvider
 
 const geistSans = GeistSans;
 const geistMono = GeistMono;
@@ -38,17 +39,18 @@ export default function RootLayout({
         suppressHydrationWarning={true}
       >
         <QueryProvider>
-
-          <SidebarProvider>
-            <AppSidebar />
-            <div className="flex flex-col flex-1 min-h-screen">
-              <AppHeader />
-              <main className="flex-1 p-4 md:p-6 lg:p-8">
-                {children}
-              </main>
-            </div>
-          </SidebarProvider>
-          <Toaster />
+          <AuthProvider> {/* Wrap with AuthProvider */}
+            <SidebarProvider>
+              <AppSidebar />
+              <div className="flex flex-col flex-1 min-h-screen">
+                <AppHeader />
+                <main className="flex-1 p-4 md:p-6 lg:p-8">
+                  {children}
+                </main>
+              </div>
+            </SidebarProvider>
+            <Toaster />
+          </AuthProvider>
         </QueryProvider>
 
       </body>

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,215 @@
+"use client";
+
+import React, { useState, FormEvent, useEffect } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Eye, EyeOff, Loader2, ShieldCheck } from 'lucide-react';
+
+type LoginStep = "credentials" | "mfa";
+
+export default function LoginPage() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [mfaCode, setMfaCode] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [uiLoading, setUiLoading] = useState(false); // UI specific loading, distinct from auth context's loading
+  const [showPassword, setShowPassword] = useState(false);
+  const [loginStep, setLoginStep] = useState<LoginStep>("credentials");
+
+  const { signInUser, currentUser, mfaRequired, completeMfa, loading: authLoading } = useAuth();
+  const router = useRouter();
+
+  useEffect(() => {
+    // Redirect if user is fully authenticated (including MFA if it was required)
+    if (currentUser && !authLoading && !mfaRequired) {
+      router.push('/');
+    }
+    // If user is present, auth is not loading, but MFA is still required, update UI
+    if (currentUser && !authLoading && mfaRequired) {
+      setLoginStep("mfa");
+      setUiLoading(false); // Ensure UI loading for credentials stops
+    }
+  }, [currentUser, authLoading, mfaRequired, router]);
+
+
+  const handleCredentialsSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setUiLoading(true);
+    try {
+      await signInUser(email, password);
+      // AuthProvider's onAuthStateChanged and the useEffect above will handle next steps (MFA or redirect)
+    } catch (err: any) {
+      let errorMessage = "Failed to sign in. Please check your credentials.";
+      if (err.code) {
+        switch (err.code) {
+          case 'auth/user-not-found':
+          case 'auth/invalid-credential': // Firebase v9+ uses invalid-credential for wrong password / user not found
+            errorMessage = "Invalid email or password.";
+            break;
+          case 'auth/invalid-email':
+            errorMessage = "Invalid email format.";
+            break;
+          case 'auth/too-many-requests':
+            errorMessage = "Too many login attempts. Please try again later.";
+            break;
+          default:
+            errorMessage = `Login failed: ${err.message || 'Unknown error'}`;
+        }
+      }
+      setError(errorMessage);
+      console.error("Login error:", err);
+      setUiLoading(false);
+    }
+    // No finally setLoading(false) here if signInUser was successful,
+    // as onAuthStateChanged will take over and potentially set mfaRequired,
+    // which then updates the UI via useEffect.
+  };
+
+  const handleMfaSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    setUiLoading(true);
+    try {
+      await completeMfa(mfaCode);
+      // Successful MFA completion will trigger onAuthStateChanged (if claims updated)
+      // or the useEffect will redirect because mfaRequired becomes false.
+      // router.push('/'); // This should be handled by useEffect
+    } catch (err: any) {
+      setError(err.message || "MFA validation failed.");
+      setUiLoading(false);
+    }
+    // No finally setLoading(false) here if completeMfa was successful,
+    // as onAuthStateChanged or useEffect will handle the redirect.
+  };
+
+  // This handles the case where the user navigates to /login but is already fully authenticated.
+  if (currentUser && !authLoading && !mfaRequired && loginStep !== "mfa") {
+     router.push('/');
+     return <div className="flex justify-center items-center min-h-screen">Redirecting...</div>;
+  }
+
+
+  return (
+    <div className="flex justify-center items-center min-h-screen bg-background p-4">
+      <Card className="w-full max-w-md shadow-2xl">
+        {loginStep === "credentials" && (
+          <>
+            <CardHeader>
+              <CardTitle className="text-3xl font-bold text-center text-primary">Welcome Back</CardTitle>
+              <CardDescription className="text-center text-muted-foreground">
+                Sign in to access your Immersive Storytelling Lab dashboard.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleCredentialsSubmit} className="space-y-6">
+                <div className="space-y-2">
+                  <Label htmlFor="email">Email</Label>
+                  <Input
+                    id="email"
+                    type="email"
+                    placeholder="you@example.com"
+                    value={email}
+                    onChange={(e) => setEmail(e.target.value)}
+                    required
+                    className="text-base"
+                    disabled={uiLoading}
+                  />
+                </div>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between">
+                    <Label htmlFor="password">Password</Label>
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={() => setShowPassword(!showPassword)}
+                      className="text-xs text-muted-foreground hover:text-foreground h-auto p-0"
+                      disabled={uiLoading}
+                    >
+                      {showPassword ? <EyeOff className="mr-1 h-4 w-4" /> : <Eye className="mr-1 h-4 w-4" />}
+                      {showPassword ? "Hide" : "Show"}
+                    </Button>
+                  </div>
+                  <div className="relative">
+                    <Input
+                      id="password"
+                      type={showPassword ? "text" : "password"}
+                      placeholder="••••••••"
+                      value={password}
+                      onChange={(e) => setPassword(e.target.value)}
+                      required
+                      className="text-base"
+                      disabled={uiLoading}
+                    />
+                  </div>
+                </div>
+                {error && <p className="text-sm text-destructive text-center bg-destructive/10 p-3 rounded-md">{error}</p>}
+                <Button type="submit" className="w-full text-lg py-3" disabled={uiLoading || authLoading}>
+                  {(uiLoading || authLoading) ? <Loader2 className="mr-2 h-5 w-5 animate-spin" /> : "Sign In"}
+                </Button>
+              </form>
+            </CardContent>
+            <CardFooter className="flex flex-col items-center text-sm">
+              <p className="text-muted-foreground">
+                {/* Don't have an account?{' '}
+                <Link href="/signup" className="font-medium text-primary hover:underline">
+                  Sign Up
+                </Link> */}
+              </p>
+            </CardFooter>
+          </>
+        )}
+
+        {loginStep === "mfa" && (
+          <>
+            <CardHeader>
+              <CardTitle className="text-3xl font-bold text-center text-primary">Two-Factor Authentication</CardTitle>
+              <CardDescription className="text-center text-muted-foreground">
+                Enter the code from your authenticator app. (Hint: any 6 digits for this mock)
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <form onSubmit={handleMfaSubmit} className="space-y-6">
+                <div className="space-y-2">
+                  <Label htmlFor="mfaCode">Authentication Code</Label>
+                  <Input
+                    id="mfaCode"
+                    type="text"
+                    placeholder="123456"
+                    value={mfaCode}
+                    onChange={(e) => setMfaCode(e.target.value)}
+                    required
+                    maxLength={6}
+                    className="text-base text-center tracking-widest"
+                    disabled={uiLoading}
+                  />
+                </div>
+                {error && <p className="text-sm text-destructive text-center bg-destructive/10 p-3 rounded-md">{error}</p>}
+                <Button type="submit" className="w-full text-lg py-3" disabled={uiLoading || authLoading}>
+                  {(uiLoading || authLoading) ? <Loader2 className="mr-2 h-5 w-5 animate-spin" /> : <><ShieldCheck className="mr-2 h-5 w-5" />Verify Code</>}
+                </Button>
+              </form>
+            </CardContent>
+             <CardFooter className="flex flex-col items-center text-sm">
+                <Button variant="link" onClick={() => {
+                    setEmail('');
+                    setPassword('');
+                    setMfaCode('');
+                    setError(null);
+                    setLoginStep('credentials');
+                    // Consider if signOutUser should be called here if user wants to restart login
+                }} disabled={uiLoading}>
+                    Back to login
+                </Button>
+            </CardFooter>
+          </>
+        )}
+      </Card>
+    </div>
+  );
+}

--- a/src/components/auth/withAuth.tsx
+++ b/src/components/auth/withAuth.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import React, { ComponentType, useEffect } from 'react';
+import { useAuth } from '@/contexts/AuthContext';
+import { useRouter } from 'next/navigation';
+import { Loader2 } from 'lucide-react';
+
+const withAuth = <P extends object>(WrappedComponent: ComponentType<P>) => {
+  const ComponentWithAuth = (props: P) => {
+    const { currentUser, loading } = useAuth();
+    const router = useRouter();
+
+    useEffect(() => {
+      if (!loading && !currentUser) {
+        router.push('/login');
+      }
+    }, [currentUser, loading, router]);
+
+    if (loading) {
+      return (
+        <div className="flex justify-center items-center min-h-screen">
+          <Loader2 className="h-12 w-12 animate-spin text-primary" />
+        </div>
+      );
+    }
+
+    if (!currentUser) {
+      // This case should ideally be handled by the useEffect redirect,
+      // but as a fallback, prevent rendering the component if not logged in.
+      // Or, if router.push hasn't completed, show a message or minimal UI.
+      return (
+        <div className="flex justify-center items-center min-h-screen">
+          <p>Redirecting to login...</p>
+          <Loader2 className="ml-2 h-6 w-6 animate-spin text-primary" />
+        </div>
+      );
+    }
+
+    return <WrappedComponent {...props} />;
+  };
+
+  // Set a display name for easier debugging
+  const displayName = WrappedComponent.displayName || WrappedComponent.name || 'Component';
+  ComponentWithAuth.displayName = `withAuth(${displayName})`;
+
+  return ComponentWithAuth;
+};
+
+export default withAuth;

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import React, { createContext, useContext, useEffect, useState, ReactNode } from 'react';
+import {
+  getAuth,
+  onAuthStateChanged,
+  User,
+  signInWithEmailAndPassword,
+  createUserWithEmailAndPassword,
+  signOut,
+  Auth,
+  IdTokenResult,
+  UserCredential
+} from 'firebase/auth';
+import { firebaseApp } from '@/lib/firebase/client';
+import { useRouter } from 'next/navigation';
+
+interface AuthContextType {
+  currentUser: User | null;
+  loading: boolean;
+  isCreator: boolean;
+  mfaRequired: boolean; // New state to indicate if MFA step is needed
+  idTokenResult: IdTokenResult | null;
+  signInUser: (email: string, pass: string) => Promise<UserCredential>;
+  signUpUser: (email: string, pass: string) => Promise<UserCredential>;
+  signOutUser: () => Promise<void>;
+  completeMfa: (code: string) => Promise<void>; // New function for MFA completion
+  fetchTokenResult: (forceRefresh?: boolean) => Promise<IdTokenResult | null>;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+// Read the environment variable for 2FA
+const enableCreator2FA = process.env.NEXT_PUBLIC_ENABLE_CREATOR_2FA === 'true';
+
+export const AuthProvider = ({ children }: { children: ReactNode }) => {
+  const [currentUser, setCurrentUser] = useState<User | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [isCreator, setIsCreator] = useState(false);
+  const [idTokenResult, setIdTokenResult] = useState<IdTokenResult | null>(null);
+  const [mfaRequired, setMfaRequired] = useState(false); // Initialize mfaRequired
+  const auth: Auth = getAuth(firebaseApp);
+  const router = useRouter();
+
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
+      setLoading(true); // Set loading true while processing user state
+      if (user) {
+        setCurrentUser(user);
+        try {
+          const tokenResult = await user.getIdTokenResult(true); // Force refresh to get latest claims
+          setIdTokenResult(tokenResult);
+          const userIsCreator = tokenResult.claims.creator === true;
+          setIsCreator(userIsCreator);
+
+          // Check if MFA is required
+          if (enableCreator2FA && userIsCreator) {
+            // For this mock, assume MFA is required if not already marked as completed this session
+            // A real implementation might check a persistent flag or a session-specific claim
+             if (!sessionStorage.getItem('mfaCompletedForSession')) {
+               setMfaRequired(true);
+             } else {
+               setMfaRequired(false);
+             }
+          } else {
+            setMfaRequired(false);
+          }
+        } catch (error) {
+          console.error("Error fetching ID token result:", error);
+          setIsCreator(false);
+          setIdTokenResult(null);
+          setMfaRequired(false);
+          // If token fetching fails critically (e.g. revoked session), sign out
+          if ((error as any).code === 'auth/user-token-expired' || (error as any).code === 'auth/invalid-user-token') {
+            await signOut(auth); // directly call signOut here, onAuthStateChanged will handle the rest
+          }
+        }
+      } else {
+        setCurrentUser(null);
+        setIsCreator(false);
+        setIdTokenResult(null);
+        setMfaRequired(false);
+        sessionStorage.removeItem('mfaCompletedForSession');
+      }
+      setLoading(false);
+    });
+
+    return () => unsubscribe();
+  }, [auth]);
+
+  const signInUser = async (email: string, pass: string): Promise<UserCredential> => {
+    setLoading(true);
+    // Clear any previous session MFA status
+    sessionStorage.removeItem('mfaCompletedForSession');
+    try {
+      const userCredential = await signInWithEmailAndPassword(auth, email, pass);
+      // onAuthStateChanged will handle setting user, claims, and mfaRequired state
+      // No need to setLoading(false) here, onAuthStateChanged will do it.
+      return userCredential;
+    } catch (error) {
+      setLoading(false); // Set loading false on error
+      throw error; // Re-throw error to be caught by login page
+    }
+  };
+
+  const signUpUser = (email: string, pass: string) => {
+    setLoading(true);
+    sessionStorage.removeItem('mfaCompletedForSession');
+    return createUserWithEmailAndPassword(auth, email, pass);
+  };
+
+  const signOutUser = async () => {
+    setLoading(true);
+    try {
+      await signOut(auth);
+      sessionStorage.removeItem('mfaCompletedForSession');
+      // onAuthStateChanged will set currentUser to null
+      router.push('/login');
+    } catch (error) {
+      console.error("Error signing out: ", error);
+      setLoading(false);
+    }
+    // setLoading(false) is handled by onAuthStateChanged after user becomes null
+  };
+
+  const completeMfa = async (code: string) => {
+    // Mock MFA completion: In a real app, verify the code with a backend.
+    // For this task, any 6-digit code is considered valid.
+    if (enableCreator2FA && isCreator && mfaRequired) {
+      if (code && code.length === 6 && /^\d+$/.test(code)) {
+        console.log("MFA code accepted (mocked):", code);
+        sessionStorage.setItem('mfaCompletedForSession', 'true'); // Mark MFA as completed for this session
+        setMfaRequired(false);
+        // Potentially, you might want to refresh the token if the backend sets a specific claim after MFA
+        // await fetchTokenResult(true);
+      } else {
+        throw new Error("Invalid MFA code (mock). Please enter a 6-digit number.");
+      }
+    }
+  };
+
+  const fetchTokenResult = async (forceRefresh: boolean = false): Promise<IdTokenResult | null> => {
+    if (currentUser) {
+      try {
+        const tokenResult = await currentUser.getIdTokenResult(forceRefresh);
+        setIdTokenResult(tokenResult);
+        setIsCreator(tokenResult.claims.creator === true);
+        // Check MFA status again after fetching token, in case claims changed
+         if (enableCreator2FA && tokenResult.claims.creator === true && !sessionStorage.getItem('mfaCompletedForSession')) {
+           setMfaRequired(true);
+         } else if (!(enableCreator2FA && tokenResult.claims.creator === true)) {
+           setMfaRequired(false);
+         }
+
+        return tokenResult;
+      } catch (error) {
+        console.error("Error fetching ID token result in fetchTokenResult:", error);
+        if ((error as any).code === 'auth/user-token-expired' || (error as any).code === 'auth/invalid-user-token') {
+          await signOutUser(); // Use the context's signOutUser which handles redirect
+        }
+        // Reset states if token fetching fails
+        setIsCreator(false);
+        setIdTokenResult(null);
+        setMfaRequired(false);
+        return null;
+      }
+    }
+    return null;
+  };
+
+  const value = {
+    currentUser,
+    loading,
+    isCreator,
+    idTokenResult,
+    mfaRequired,
+    signInUser,
+    signUpUser,
+    signOutUser,
+    completeMfa,
+    fetchTokenResult,
+  };
+
+  return <AuthContext.Provider value={value}>{!loading && children}</AuthContext.Provider>;
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/src/hooks/useSubmitFeedback.ts
+++ b/src/hooks/useSubmitFeedback.ts
@@ -1,46 +1,57 @@
 import { useMutation } from '@tanstack/react-query';
-import { FeedbackReport } from '@/lib/feedback-types'; // Assuming FeedbackReport is the main type
-import { getAuth } from 'firebase/auth';
-import { app } from '@/lib/firebase/client'; // Ensure 'app' is exported from client Firebase setup
+import { FeedbackReport } from '@/lib/feedback-types';
+import { getAuth, User } from 'firebase/auth';
+import { firebaseApp } from '@/lib/firebase/client'; // Corrected import name
+import { useAuth } from '@/contexts/AuthContext'; // Import useAuth
 
-// Define the input type for the hook, omitting server-set fields
 export type SubmitFeedbackHookInput = Pick<
   FeedbackReport,
   'prototypeId' | 'reportedContentPath' | 'reason'
 > & {
-  category?: FeedbackReport['category']; // Optional category
+  category?: FeedbackReport['category'];
 };
 
-const mutationFn = async (feedbackInput: SubmitFeedbackHookInput) => {
-  const auth = getAuth(app);
-  const currentUser = auth.currentUser;
-
-  if (!currentUser) {
-    throw new Error('User not authenticated. Cannot submit feedback.');
-  }
-
-  const idToken = await currentUser.getIdToken();
-
-  const response = await fetch('/api/feedback/report', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      Authorization: `Bearer ${idToken}`,
-    },
-    body: JSON.stringify(feedbackInput),
-  });
-
-  if (!response.ok) {
-    const errorData = await response.json().catch(() => ({ message: 'Failed to submit feedback. Unknown error.' }));
-    throw new Error(errorData.message || `Request failed with status ${response.status}`);
-  }
-
-  return response.json();
-};
+// It's better to define mutationFn outside if it doesn't need to be recreated on every hook call,
+// or pass signOutUser directly if the hook's structure allows.
+// For simplicity here, we'll call useAuth inside the hook, which means mutationFn is redefined.
+// A more optimized approach might involve a stable signOutUser reference.
 
 export const useSubmitFeedback = () => {
+  const { signOutUser, currentUser } = useAuth(); // Get signOutUser and currentUser from context
+
+  const mutationFnWithAuthHandling = async (feedbackInput: SubmitFeedbackHookInput) => {
+    // currentUser from context is preferred over getAuth().currentUser for consistency with AuthProvider state
+    if (!currentUser) {
+      throw new Error('User not authenticated. Cannot submit feedback.');
+    }
+
+    const idToken = await currentUser.getIdToken();
+
+    const response = await fetch('/api/feedback/report', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${idToken}`,
+      },
+      body: JSON.stringify(feedbackInput),
+    });
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        // Token is invalid or expired, sign out user
+        await signOutUser();
+        // Error will still be thrown, but user is now logged out
+        // The component using this hook or a global error boundary should handle the redirect
+        // or the signOutUser itself (which now includes router.push) will handle it.
+      }
+      const errorData = await response.json().catch(() => ({ message: 'Failed to submit feedback. Unknown error.' }));
+      throw new Error(errorData.message || `Request failed with status ${response.status}`);
+    }
+
+    return response.json();
+  };
+
   return useMutation({
-    mutationFn,
-    // onSuccess, onError, etc. can be handled by the component using the hook
+    mutationFn: mutationFnWithAuthHandling,
   });
 };


### PR DESCRIPTION
- Established basic client-side authentication using Firebase:
  - Created AuthContext with onAuthStateChanged for user state management.
  - Implemented Login page with email/password sign-in.
  - Updated Sidebar to reflect auth state and handle logout.
  - Added withAuth HOC for route protection.
- Implemented client-side handling for token expiration:
  - API hooks (e.g., useSubmitFeedback) now trigger logout on 401/403 errors.
- Added optional Two-Factor Authentication (mock UI flow) for "creator" users:
  - Controlled by NEXT_PUBLIC_ENABLE_CREATOR_2FA environment variable.
  - AuthContext checks for 'creator' custom claim.
  - Login page presents an MFA code step if required (mocked verification).
- Added .env.example with relevant Firebase and 2FA environment variables.