### PR TITLE
Fix: Add missing properties to Panel type

### DIFF
--- a/packages/types/src/storyboard.types.ts
+++ b/packages/types/src/storyboard.types.ts
@@ -12,6 +12,8 @@ export interface Panel {
   camera?: string; // Optional camera shot type (e.g., "Close Up", "Wide Shot")
   durationMs?: number; // Optional suggested duration in milliseconds
   generatedAt: string; // ISO timestamp of when the panel was generated
+  panelNumber?: number; // Optional panel number
+  dialogueOrSound?: string; // Optional dialogue or sound description
   // Add any other panel-specific metadata here
 }
 


### PR DESCRIPTION
Adds `panelNumber` and `dialogueOrSound` to the `Panel` type definition in `packages/types/src/storyboard.types.ts`.

This resolves TypeScript errors in `src/app/storyboard-studio/page.tsx` where these properties were being accessed but did not exist on the type.