### PR TITLE
Fix: Remove unknown --turbopack flag from dev script

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "scripts": {
-    "dev": "next dev --turbopack -p 9002",
+    "dev": "next dev -p 9002",
     "genkit:dev": "genkit start -- tsx src/ai/dev.ts",
     "genkit:watch": "genkit start -- tsx --watch src/ai/dev.ts",
     "build": "next build",


### PR DESCRIPTION
The `--turbopack` flag was causing an error when starting the development server. This commit removes the flag from the `dev` script in `package.json`.

Turbopack is not explicitly enabled in `next.config.js`, so this change will result in using the default Next.js development server (Webpack). If Turbopack is desired, it needs to be configured in `next.config.js`.