### PR TITLE
Fix: Configure Firebase Hosting for local Next.js development

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -9,29 +9,21 @@
     ],
     "rewrites": [
       {
-        "source": "/api/**",
-        "run": {
-          "serviceId": "your-isl-sixr-tv-cloud-run-service-id",
-          "region": "your-cloud-run-region"
-        }
-      },
-      {
         "source": "**",
-        "run": {
-          "serviceId": "your-isl-sixr-tv-cloud-run-service-id",
-          "region": "your-cloud-run-region"
-        }
+        "function": "webApp"
       }
     ]
   },
   "functions": [
     {
       "source": "functions",
-      "runtime": "nodejs18"
+      "runtime": "nodejs18",
+      "codebase": "default"
     },
     {
       "source": "ai-microservice",
-      "runtime": "nodejs18"
+      "runtime": "nodejs18",
+      "codebase": "ai"
     }
   ]
 }


### PR DESCRIPTION
Modified firebase.json to route all hosting requests to a 'webApp' function. This function is intended to proxy to the local Next.js development server (e.g., http://localhost:9002) when using Firebase emulators.

This change aims to resolve 404 errors when launching the application locally via Firebase Studio by providing a mechanism for the hosting emulator to serve the Next.js application.

Added 'codebase' attributes to function definitions for clarity.